### PR TITLE
Fix invalid link in RSS feed

### DIFF
--- a/feed.rss
+++ b/feed.rss
@@ -69,7 +69,7 @@
                         
                         <p>This is Web 1.0 slightly updated. Let's call it Web 1.1</p>
                         
-                        <p>You can read my specific self-imposed rules for it <a href="../pages/DesignPrinciples.html"> here </a> - and specific technical specifications <a href="../pages/DevEnvironment.html"> here.</a></p>
+                        <p>You can read my specific self-imposed rules for it <a href="../pages/DesignPrinciples.html"> here </a> - and specific technical specifications <a href="../pages/TechStack.html"> here.</a></p>
                     </div>
 
                 ]]>


### PR DESCRIPTION
## Summary
- correct path in feed.rss to existing TechStack page

## Testing
- `xmllint --noout feed.rss` *(fails: Namespace prefix content not defined)*

------
https://chatgpt.com/codex/tasks/task_e_683f782e0a94832e976db69746f91b40